### PR TITLE
New Version Compatibility

### DIFF
--- a/DCE_IDandPhaseSelect/Breast_DCEMRI_FTV_plugins1/Exam_Ident_and_timing.py
+++ b/DCE_IDandPhaseSelect/Breast_DCEMRI_FTV_plugins1/Exam_Ident_and_timing.py
@@ -28,7 +28,6 @@ from Breast_DCEMRI_FTV_plugins1 import chooseEarly_LateByManufacturer
 from Breast_DCEMRI_FTV_plugins1 import gzip_gunzip_pyfuncs
 import os
 import pydicom
-import dicom
 import numpy as np
 import slicer
 import qt

--- a/DCE_IDandPhaseSelect/Breast_DCEMRI_FTV_plugins1/Get_header_info_all_manufacturer.py
+++ b/DCE_IDandPhaseSelect/Breast_DCEMRI_FTV_plugins1/Get_header_info_all_manufacturer.py
@@ -54,6 +54,47 @@ def findDicomFilePaths(folderpath, minFiles=1):
             return [os.path.join(subpath, n) for n in sub_names]
     return []
 
+def _folderLabelFromPath(relative_path):
+    base_name = os.path.basename(relative_path)
+    if os.sep not in relative_path and base_name.isdecimal():
+        return int(base_name)
+    return relative_path.replace('\\', '/')
+
+def _folderSortKey(label):
+    parts = str(label).replace('\\', '/').split('/')
+    key = []
+    for part in parts:
+        if part.isdecimal():
+            key.append((0, int(part)))
+        else:
+            key.append((1, part))
+    return key
+
+def _collectImageFolderPaths(exampath):
+    """Return exam-relative paths to folders that contain DICOM series."""
+    img_folder_paths = []
+    folders = [directory for directory in os.listdir(exampath) if os.path.isdir(os.path.join(exampath, directory))]
+
+    for folder in folders:
+        if 'SlicerReport' in folder:
+            continue
+
+        curr_path = os.path.join(exampath, folder)
+        if len(_dicomFileNamesInDirectory(curr_path)) >= 1:
+            img_folder_paths.append(folder)
+            continue
+
+        nested = []
+        for sub in sorted(os.listdir(curr_path)):
+            subpath = os.path.join(curr_path, sub)
+            if os.path.isdir(subpath) and len(_dicomFileNamesInDirectory(subpath)) >= 1:
+                nested.append(os.path.join(folder, sub))
+
+        if len(nested) > 0:
+            img_folder_paths.extend(nested)
+
+    return img_folder_paths
+
 #Class FolderInfo is class that is used to construct objects with all of the header info for a particular folder in an exam.
 #one class object per DICOM folder within exam
 class FolderInfo:
@@ -322,36 +363,15 @@ class FolderInfo:
 
 
 def fillExamFolderInfoStructures(exampath):
-    #return list of folders in exampath
-    folders = [directory for directory in os.listdir(exampath) if os.path.isdir(os.path.join(exampath,directory))]
-
-    #Edit 5/29/2020: Instead of using folder name as criterion, check if the folder actually has
-    #DICOMs in and add to img_folders only if it does have DICOMs.
-    img_folders = []
-    for i in range(len(folders)):
-        curr_path = os.path.join(exampath,folders[i])
-
-        #Edit 7/6/2020: Program code to not count SlicerReports folder as an image folder
-        if('SlicerReport' in folders[i]):
-            continue
-
-        if len(findDicomFilePaths(curr_path, minFiles=1)) > 0:
-            if(folders[i].isdecimal()):
-                img_folders.append(int(folders[i]))
-            else:
-                img_folders.append(folders[i])
-
-    img_folders = sorted(img_folders) #Edit 2/16/2021: Sort the folders in increasing numerical order
-                                      #because that is more user-friendly for manual DCE folder ID.
+    img_folder_paths = _collectImageFolderPaths(exampath)
+    img_folders = sorted([_folderLabelFromPath(path) for path in img_folder_paths], key=_folderSortKey)
     print(img_folders)
 
-    #using list of DICOM image folders, make list of structures with DICOM header info from each folder
     all_folders_info = []
     for j in range(len(img_folders)):
-        curr_path = os.path.join(exampath,str(img_folders[j]))
+        curr_path = os.path.join(exampath, str(img_folders[j]))
         curr_folder_info = FolderInfo(curr_path)
         all_folders_info.append(curr_folder_info)
-
 
     return img_folders, all_folders_info
 

--- a/DCE_IDandPhaseSelect/Breast_DCEMRI_FTV_plugins1/Get_header_info_all_manufacturer.py
+++ b/DCE_IDandPhaseSelect/Breast_DCEMRI_FTV_plugins1/Get_header_info_all_manufacturer.py
@@ -23,7 +23,6 @@
 
 
 import pydicom
-import dicom
 import os
 import re
 import numpy as np
@@ -69,8 +68,7 @@ class FolderInfo:
                     header = pydicom.dcmread(img1path,stop_before_pixels = True,force=True)
                     headerend = pydicom.dcmread(imgendpath,stop_before_pixels = True,force=True)
                 except:
-                    header = dicom.read_file(img1path)
-                    headerend = dicom.read_file(imgendpath)
+                    raise RuntimeError("Unable to read DICOM header from " + str(img1path))
 
             #fill header info
             self.studydate = header.StudyDate

--- a/DCE_IDandPhaseSelect/Breast_DCEMRI_FTV_plugins1/Get_header_info_all_manufacturer.py
+++ b/DCE_IDandPhaseSelect/Breast_DCEMRI_FTV_plugins1/Get_header_info_all_manufacturer.py
@@ -29,33 +29,42 @@ import numpy as np
 from statistics import mode
 import hashlib
 
+def _dicomFileNamesInDirectory(directory):
+    names = []
+    for f in os.listdir(directory):
+        full = os.path.join(directory, f)
+        if not os.path.isfile(full):
+            continue
+        if f.endswith('.dcm') or f.endswith('.DCM') or f.isdigit():
+            names.append(f)
+    return sorted(names)
+
+def findDicomFilePaths(folderpath, minFiles=1):
+    """Return sorted full paths to DICOM files in folderpath or its subfolders."""
+    names = _dicomFileNamesInDirectory(folderpath)
+    if len(names) >= minFiles:
+        return [os.path.join(folderpath, n) for n in names]
+
+    for sub in sorted(os.listdir(folderpath)):
+        subpath = os.path.join(folderpath, sub)
+        if not os.path.isdir(subpath):
+            continue
+        sub_names = _dicomFileNamesInDirectory(subpath)
+        if len(sub_names) >= minFiles:
+            return [os.path.join(subpath, n) for n in sub_names]
+    return []
+
 #Class FolderInfo is class that is used to construct objects with all of the header info for a particular folder in an exam.
 #one class object per DICOM folder within exam
 class FolderInfo:
     def __init__(self,folderpath):
         #switched from sitk method to os.listdir method because it is much faster
         #edit 5/29/2020: added verification that we're reading .dcm files because some numbered folders might not have DICOMs in them
-        files = [f for f in os.listdir(folderpath) if f.endswith('.dcm')]
-        FILES = [f for f in os.listdir(folderpath) if f.endswith('.DCM')]
-        files_noext = [f for f in os.listdir(folderpath) if f.isdigit()] #edit 1/26/2021: In some folders, there is a series of DICOM images
-                                                                         #with no .dcm or .DCM extension, but all the files have a number as the filename.
+        dcm_files = findDicomFilePaths(folderpath, minFiles=1)
 
-        if(len(files)>0 or len(FILES)>0 or len(files_noext) > 0):
-
-            if len(files)>0:
-                dcm_files = sorted(files)
-                img1path = os.path.join(folderpath,dcm_files[0])
-                imgendpath = os.path.join(folderpath,dcm_files[len(dcm_files)-1])
-
-            if len(FILES)>0:
-                dcm_files = sorted(FILES)
-                img1path = os.path.join(folderpath,dcm_files[0])
-                imgendpath = os.path.join(folderpath,dcm_files[len(dcm_files)-1])
-
-            if len(files_noext)>0:
-                dcm_files = sorted(files_noext)
-                img1path = os.path.join(folderpath,dcm_files[0])
-                imgendpath = os.path.join(folderpath,dcm_files[len(dcm_files)-1])
+        if(len(dcm_files) > 0):
+            img1path = dcm_files[0]
+            imgendpath = dcm_files[-1]
 
             print("Reading header from file:")
             print(img1path)
@@ -321,21 +330,16 @@ def fillExamFolderInfoStructures(exampath):
     img_folders = []
     for i in range(len(folders)):
         curr_path = os.path.join(exampath,folders[i])
-        curr_files = [f for f in os.listdir(curr_path) if f.endswith('.dcm')]
-        curr_FILES = [f for f in os.listdir(curr_path) if f.endswith('.DCM')]
-        curr_files_noext = [f for f in os.listdir(curr_path) if f.isdigit()] #edit 1/26/2021: In some folders, there is a series of DICOM images
-                                                                         #with no .dcm or .DCM extension, but all the files have a number as the filename.
 
         #Edit 7/6/2020: Program code to not count SlicerReports folder as an image folder
-        #Edit 10/28/2020: Program code to only look at folders that have numerical names
-        #Edit 7/6/2021: To make compatible with TCIA Duke exams, must consider folders that start
-        #with a number as image folders too.
-        if( (len(curr_files)>0 or len(curr_FILES)>0 or len(curr_files_noext)>0) and ('SlicerReport' not in folders[i]) and (folders[i].isdecimal() or folders[i][0].isdecimal()) ):
+        if('SlicerReport' in folders[i]):
+            continue
+
+        if len(findDicomFilePaths(curr_path, minFiles=1)) > 0:
             if(folders[i].isdecimal()):
                 img_folders.append(int(folders[i]))
             else:
-                if(folders[i][0].isdecimal()):
-                    img_folders.append(folders[i])
+                img_folders.append(folders[i])
 
     img_folders = sorted(img_folders) #Edit 2/16/2021: Sort the folders in increasing numerical order
                                       #because that is more user-friendly for manual DCE folder ID.

--- a/DCE_IDandPhaseSelect/Breast_DCEMRI_FTV_plugins1/chooseEarly_LateByManufacturer.py
+++ b/DCE_IDandPhaseSelect/Breast_DCEMRI_FTV_plugins1/chooseEarly_LateByManufacturer.py
@@ -32,6 +32,7 @@ import Breast_DCEMRI_FTV_plugins1
 from Breast_DCEMRI_FTV_plugins1 import timing_info_class_all_manufacturer #function for populating structures of timing info from DICOM headers
 from Breast_DCEMRI_FTV_plugins1 import multivolume_folder_sort #function for sorting slices in correct order for a multivolume folder
 from Breast_DCEMRI_FTV_plugins1 import gzip_gunzip_pyfuncs
+from Breast_DCEMRI_FTV_plugins1.Get_header_info_all_manufacturer import findDicomFilePaths
 
 #Function that tells you which post-contrast image # is early or late
 def findClosestTime(imgtimes,time):
@@ -82,21 +83,10 @@ def chooseEarlyLateGE_Siemens(exampath,dce_folders,manufacturer,earlyadd, latead
         phaseslc1paths = []
         for fnum in range(len(dce_folders)):
             curr_path = os.path.join(exampath,str(dce_folders[fnum]))
-            files = [f for f in os.listdir(curr_path) if f.endswith('.dcm')]
-            FILES = [f for f in os.listdir(curr_path) if f.endswith('.DCM')]
-            files_noext = [f for f in os.listdir(curr_path) if f.isdigit()] #edit 1/26/2021: In some folders, there is a series of DICOM images
-                                                                            #with no .dcm or .DCM extension, but all the files have a number as the filename.
-
-            if len(files) > 0:
-                files = sorted(files)
-                curr_img_path = os.path.join(curr_path,files[0])
-            if len(FILES) > 0:
-                FILES = sorted(FILES)
-                curr_img_path = os.path.join(curr_path,FILES[0])
-            if len(files_noext)>0:
-                curr_img_path = os.path.join(curr_path,files_noext[0])
-
-
+            dcm_paths = findDicomFilePaths(curr_path, minFiles=1)
+            if len(dcm_paths) == 0:
+                continue
+            curr_img_path = dcm_paths[0]
             phaseslc1paths.append(curr_img_path)
 
     #use one slice from each phase in same folder if there is only one DCE folder

--- a/DCE_IDandPhaseSelect/Breast_DCEMRI_FTV_plugins1/chooseEarly_LateByManufacturer.py
+++ b/DCE_IDandPhaseSelect/Breast_DCEMRI_FTV_plugins1/chooseEarly_LateByManufacturer.py
@@ -25,7 +25,6 @@
 
 import time
 import pydicom
-import dicom
 import os
 import numpy as np
 

--- a/DCE_IDandPhaseSelect/Breast_DCEMRI_FTV_plugins1/compute_lps_to_rcs.py
+++ b/DCE_IDandPhaseSelect/Breast_DCEMRI_FTV_plugins1/compute_lps_to_rcs.py
@@ -22,7 +22,6 @@
 
 import os
 import pydicom
-import dicom
 import numpy as np
 import re
 
@@ -72,7 +71,7 @@ def computeAffineAndAffineInverse(exampath,prefoldernum,nslice,fsort):
     try:
         img1 = pydicom.dcmread(file1)
     except:
-        img1 = dicom.read_file(file1)
+        img1 = pydicom.dcmread(file1, force=True)
 
     img1_orient = img1[0x20,0x37] #Image Orientation (Patient)
     img1_orient = [float(i) for i in img1_orient] #convert from list of strings to list of floats (numeric)
@@ -109,7 +108,7 @@ def computeAffineAndAffineInverse(exampath,prefoldernum,nslice,fsort):
     try:
         imgN = pydicom.dcmread(fileN)
     except:
-        imgN = dicom.read_file(fileN)
+        imgN = pydicom.dcmread(fileN, force=True)
 
     imgN_pos = imgN[0x20,0x32] #Image Position (Patient) for last slice
     #Next 2 lines convert from header field with values to list of floats
@@ -230,7 +229,7 @@ def getVOIVoxelsFromInverseAffine(exampath,xmlfilepath,prefoldernum,nslice,fsort
     try:
         img1 = pydicom.dcmread(file1)
     except:
-        img1 = dicom.read_file(file1)
+        img1 = pydicom.dcmread(file1, force=True)
 
     voi_mask = np.zeros((int(img1.Rows),int(img1.Columns),len(files)))
     voi_mask[xs:xf,ys:yf,zs:zf] = 1

--- a/DCE_IDandPhaseSelect/Breast_DCEMRI_FTV_plugins1/gzip_gunzip_pyfuncs.py
+++ b/DCE_IDandPhaseSelect/Breast_DCEMRI_FTV_plugins1/gzip_gunzip_pyfuncs.py
@@ -151,7 +151,7 @@ def gunzipAllFilesDCE(exampath,dce_folder):
     #Edit 2/4/2021: Only do this if all of the DICOMs are gzipped
     if(len(filesdcmgz) == len(files)):
         cmd_base = r'"C:\Program Files\7-Zip\7z" x '
-        cmd_7z = cmd_base + dcegzipped_paths[0] + '\*' + ' -o' + dcegunzip_dest_paths[0]
+        cmd_7z = cmd_base + dcegzipped_paths[0] + r'\*' + ' -o' + dcegunzip_dest_paths[0]
         os.system(cmd_7z) #execute above command
     else:
         #Edit 2/4/2021: If all the DICOMs are not gzipped, use copy_tree
@@ -171,7 +171,7 @@ def gunzipAllFilesDCE(exampath,dce_folder):
             #Edit 2/4/2021: Once you've looped through the files to ensure that all are gzipped,
             #gunzip all of them to the new gunzipped directory.
             cmd_base = r'"C:\Program Files\7-Zip\7z" x '
-            cmd_7z = cmd_base + dcegzipped_paths[0] + '\*' + ' -o' + dcegunzip_dest_paths[0]
+            cmd_7z = cmd_base + dcegzipped_paths[0] + r'\*' + ' -o' + dcegunzip_dest_paths[0]
             os.system(cmd_7z) #execute above command
 
     return

--- a/DCE_IDandPhaseSelect/Breast_DCEMRI_FTV_plugins1/read_DCE_images_to_numpy.py
+++ b/DCE_IDandPhaseSelect/Breast_DCEMRI_FTV_plugins1/read_DCE_images_to_numpy.py
@@ -26,6 +26,51 @@ import re
 import os
 import slicer
 import vtk
+import SimpleITK as sitk
+import sitkUtils
+
+def _dicomFileNamesInDirectory(path):
+    names = []
+    for f in os.listdir(path):
+        full = os.path.join(path, f)
+        if not os.path.isfile(full):
+            continue
+        if f.endswith('.dcm') or f.endswith('.DCM') or f.isdigit():
+            names.append(f)
+    return sorted(names)
+
+def _dicomSeriesFileNamesInDirectory(path):
+    series_ids = sitk.ImageSeriesReader.GetGDCMSeriesIDs(path)
+    if len(series_ids) > 0:
+        return list(sitk.ImageSeriesReader.GetGDCMSeriesFileNames(path, series_ids[0]))
+    return addFullPathToFileList(path, _dicomFileNamesInDirectory(path))
+
+def _dicomSeriesToNumpy(dicom_names):
+    reader = sitk.ImageSeriesReader()
+    reader.SetFileNames(list(dicom_names))
+    sitk_image = reader.Execute()
+    volume = sitkUtils.PushVolumeToSlicer(sitk_image)
+
+    m = vtk.vtkMatrix4x4()
+    volume.GetRASToIJKMatrix(m)
+
+    npimg = slicer.util.arrayFromVolume(volume)
+    slicer.mrmlScene.RemoveNode(volume)
+    return m, npimg
+
+def _volumeArrayToNumpy(m, npimg, to_float64=True):
+    npimg = np.transpose(npimg, (2, 1, 0))
+    if to_float64:
+        npimg = npimg.astype('float64')
+    else:
+        try:
+            npimg = npimg.astype('float64')
+        except:
+            try:
+                npimg = npimg.astype('float32')
+            except:
+                npimg = npimg.astype('int8')
+    return m, npimg
 
 #Philips correct z-order of slices
 #Edit 6/10/2020: By checking both OHSC and UChic exams from Philips, I realized that the routine from
@@ -42,28 +87,14 @@ import vtk
 #4/3/2020: New version of readInputToNumpy using SimpleITK
 #Edit 6/16/2020: Incorporate Andrey's suggested method of reading DICOM series into Slicer
 def readInputToNumpy(path):
-    #Edit 6/16/2020: os.listdir and adding full path may be faster
-    dicom_names = os.listdir(path)
-    dicom_names = addFullPathToFileList(path,dicom_names) #call function for converting list of DCM filenames to list of DCM file names with path included
-
-    plugin = slicer.modules.dicomPlugins['DICOMScalarVolumePlugin']()
-    loadables = plugin.examine([dicom_names])
-    volume = plugin.load(loadables[0])
-
-    #store RASToIJKMatrix in m so that you can use this to correct output images' orientations
-    m = vtk.vtkMatrix4x4()
-    volume.GetRASToIJKMatrix(m)
-
-    npimg = slicer.util.arrayFromVolume(volume)
+    dicom_names = _dicomSeriesFileNamesInDirectory(path)
+    m, npimg = _dicomSeriesToNumpy(dicom_names)
     print("image dimensions")
     print(np.shape(npimg))
     print("image min and max after arrayFromVolume")
     print(np.amin(npimg))
     print(np.amax(npimg))
-    slicer.mrmlScene.RemoveNode(volume) #this is how to prevent "unnamed volume ..." from staying in slicer window
-    npimg = np.transpose(npimg,(2,1,0)) #edit 4/27/2020: using dimension order x,y,z gives same orientation as input DICOM (original numpy one is z,y,x)
-    #npimg = np.flip(npimg,2) #apparently slicer method of reading DICOM series always reverses slice order from what we want, so add this flip
-    npimg = npimg.astype('float64') #convert to float64 to avoid dynamic range issues when calculating PE and SER
+    m, npimg = _volumeArrayToNumpy(m, npimg, to_float64=True)
     print("image min and max after float64 conversion")
     print(np.amin(npimg))
     print(np.amax(npimg))
@@ -112,32 +143,12 @@ def readPhilipsImageToNumpy(exampath,dce_folders,fsort,postContrastNum):
     except:
         print("Not checking image size, therefore will not remove slices.")
 
-    plugin = slicer.modules.dicomPlugins['DICOMScalarVolumePlugin']()
-    loadables = plugin.examine([dicom_names])
-    volume = plugin.load(loadables[0])
-
-    #store RASToIJKMatrix in m so that you can use this to correct output images' orientations
-    m = vtk.vtkMatrix4x4()
-    volume.GetRASToIJKMatrix(m)
-
-    npimg = slicer.util.arrayFromVolume(volume)
+    m, npimg = _dicomSeriesToNumpy(dicom_names)
     print("image min and max after arrayFromVolume")
     print(dcepath)
     print(np.amin(npimg))
     print(np.amax(npimg))
-    slicer.mrmlScene.RemoveNode(volume) #this is how to prevent "unnamed volume ..." from staying in slicer window
-
-    npimg = np.transpose(npimg,(2,1,0)) #edit 4/27/2020: using dimension order x,y,z gives same orientation as input DICOM (original numpy one is z,y,x)
-    #npimg = np.flip(npimg,2) #apparently slicer method of reading DICOM series always reverses slice order from what we want, so add this flip
-    try:
-        npimg = npimg.astype('float64') #convert to float64 to avoid dynamic range issues when calculating PE and SER
-    except:
-        try:
-            npimg = npimg.astype('float32')
-        except:
-            npimg = npimg.astype('int8')
-
-    return m, npimg
+    return _volumeArrayToNumpy(m, npimg, to_float64=False)
 
 #Wrote this function for quickly converting list of DCM filenames to list of DCM file names with path included
 def addFullPathToFileList(path,files):

--- a/DCE_IDandPhaseSelect/Breast_DCEMRI_FTV_plugins1/read_DCE_images_to_numpy.py
+++ b/DCE_IDandPhaseSelect/Breast_DCEMRI_FTV_plugins1/read_DCE_images_to_numpy.py
@@ -22,7 +22,6 @@
 
 import numpy as np
 import pydicom
-import dicom
 import re
 import os
 import slicer

--- a/DCE_IDandPhaseSelect/Breast_DCEMRI_FTV_plugins1/read_DCE_images_to_numpy.py
+++ b/DCE_IDandPhaseSelect/Breast_DCEMRI_FTV_plugins1/read_DCE_images_to_numpy.py
@@ -26,50 +26,54 @@ import re
 import os
 import slicer
 import vtk
-import SimpleITK as sitk
-import sitkUtils
 
-def _dicomFileNamesInDirectory(path):
-    names = []
-    for f in os.listdir(path):
-        full = os.path.join(path, f)
-        if not os.path.isfile(full):
-            continue
-        if f.endswith('.dcm') or f.endswith('.DCM') or f.isdigit():
-            names.append(f)
-    return sorted(names)
+def _dicomDatabaseIsOpen():
+    db = slicer.dicomDatabase
+    if db is None:
+        return False
+    try:
+        return db.database().isOpen()
+    except AttributeError:
+        return False
 
-def _dicomSeriesFileNamesInDirectory(path):
-    series_ids = sitk.ImageSeriesReader.GetGDCMSeriesIDs(path)
-    if len(series_ids) > 0:
-        return list(sitk.ImageSeriesReader.GetGDCMSeriesFileNames(path, series_ids[0]))
-    return addFullPathToFileList(path, _dicomFileNamesInDirectory(path))
+def _ensureDicomDatabaseOpen():
+    if _dicomDatabaseIsOpen():
+        return
 
-def _dicomSeriesToNumpy(dicom_names):
-    reader = sitk.ImageSeriesReader()
-    reader.SetFileNames(list(dicom_names))
-    sitk_image = reader.Execute()
-    volume = sitkUtils.PushVolumeToSlicer(sitk_image)
+    db = slicer.dicomDatabase
+    if db is None:
+        return
 
+    databaseFilename = None
+    try:
+        databaseFilename = slicer.app.applicationLogic().GetDICOMDatabaseFilename()
+    except AttributeError:
+        pass
+
+    if databaseFilename:
+        db.openDatabase(databaseFilename)
+        if _dicomDatabaseIsOpen():
+            return
+
+    db_dir = os.path.join(os.path.expanduser('~'), '.slicer', 'FTV_DICOM')
+    os.makedirs(db_dir, exist_ok=True)
+    db.openDatabase(os.path.join(db_dir, 'DICOM.db'))
+
+def _loadDicomSeriesVolume(dicom_names):
+    _ensureDicomDatabaseOpen()
+    plugin = slicer.modules.dicomPlugins['DICOMScalarVolumePlugin']()
+    loadables = plugin.examine([dicom_names])
+    if not loadables:
+        raise RuntimeError('DICOMScalarVolumePlugin found no loadable series')
+    return plugin.load(loadables[0])
+
+def _volumeToNumpy(volume):
     m = vtk.vtkMatrix4x4()
     volume.GetRASToIJKMatrix(m)
 
     npimg = slicer.util.arrayFromVolume(volume)
     slicer.mrmlScene.RemoveNode(volume)
-    return m, npimg
-
-def _volumeArrayToNumpy(m, npimg, to_float64=True):
     npimg = np.transpose(npimg, (2, 1, 0))
-    if to_float64:
-        npimg = npimg.astype('float64')
-    else:
-        try:
-            npimg = npimg.astype('float64')
-        except:
-            try:
-                npimg = npimg.astype('float32')
-            except:
-                npimg = npimg.astype('int8')
     return m, npimg
 
 #Philips correct z-order of slices
@@ -87,14 +91,17 @@ def _volumeArrayToNumpy(m, npimg, to_float64=True):
 #4/3/2020: New version of readInputToNumpy using SimpleITK
 #Edit 6/16/2020: Incorporate Andrey's suggested method of reading DICOM series into Slicer
 def readInputToNumpy(path):
-    dicom_names = _dicomSeriesFileNamesInDirectory(path)
-    m, npimg = _dicomSeriesToNumpy(dicom_names)
+    dicom_names = os.listdir(path)
+    dicom_names = addFullPathToFileList(path, dicom_names)
+
+    volume = _loadDicomSeriesVolume(dicom_names)
+    m, npimg = _volumeToNumpy(volume)
     print("image dimensions")
     print(np.shape(npimg))
     print("image min and max after arrayFromVolume")
     print(np.amin(npimg))
     print(np.amax(npimg))
-    m, npimg = _volumeArrayToNumpy(m, npimg, to_float64=True)
+    npimg = npimg.astype('float64')
     print("image min and max after float64 conversion")
     print(np.amin(npimg))
     print(np.amax(npimg))
@@ -130,7 +137,7 @@ def readPhilipsImageToNumpy(exampath,dce_folders,fsort,postContrastNum):
         dcepath = os.path.join(exampath,str(dce_folders[0]))
 
     dicom_names = fsort[postContrastNum][:]
-    dicom_names = addFullPathToFileList(dcepath,dicom_names) #call function for converting list of DCM filenames to list of DCM file names with path included
+    dicom_names = addFullPathToFileList(dcepath,dicom_names)
 
     #7/20/2021: If image dimensions > 700 x 700 x 200, cut off
     #20 slices from each side. Hopefully this prevents numpy
@@ -143,12 +150,21 @@ def readPhilipsImageToNumpy(exampath,dce_folders,fsort,postContrastNum):
     except:
         print("Not checking image size, therefore will not remove slices.")
 
-    m, npimg = _dicomSeriesToNumpy(dicom_names)
+    volume = _loadDicomSeriesVolume(dicom_names)
+    m, npimg = _volumeToNumpy(volume)
     print("image min and max after arrayFromVolume")
     print(dcepath)
     print(np.amin(npimg))
     print(np.amax(npimg))
-    return _volumeArrayToNumpy(m, npimg, to_float64=False)
+    try:
+        npimg = npimg.astype('float64')
+    except:
+        try:
+            npimg = npimg.astype('float32')
+        except:
+            npimg = npimg.astype('int8')
+
+    return m, npimg
 
 #Wrote this function for quickly converting list of DCM filenames to list of DCM file names with path included
 def addFullPathToFileList(path,files):
@@ -157,4 +173,3 @@ def addFullPathToFileList(path,files):
         fullfilei = os.path.join(path,filei)
         files[i] = fullfilei
     return files
-

--- a/DCE_IDandPhaseSelect/Breast_DCEMRI_FTV_plugins1/timing_info_class_all_manufacturer.py
+++ b/DCE_IDandPhaseSelect/Breast_DCEMRI_FTV_plugins1/timing_info_class_all_manufacturer.py
@@ -23,7 +23,6 @@
 
 import os
 import pydicom
-import dicom
 
 class GE_TimingInfo:
     def __init__(self,img1path,numpaths):
@@ -33,7 +32,7 @@ class GE_TimingInfo:
             try:
                 header = pydicom.dcmread(img1path,stop_before_pixels = True)
             except:
-                header = dicom.read_file(img1path)
+                header = pydicom.dcmread(img1path, stop_before_pixels=True, force=True)
 
             try:
                 self.contenttime = header[0x8,0x33].value
@@ -110,7 +109,7 @@ class SiemensTimingInfo:
         try:
             header = pydicom.dcmread(img1path,stop_before_pixels = True)
         except:
-            header = dicom.read_file(img1path)
+            header = pydicom.dcmread(img1path, stop_before_pixels=True, force=True)
 
         try:
             self.contenttime = header[0x8,0x33].value #Edit 1/20/2021: See if rounding this to nearest whole number prevents error for 34306 v20
@@ -168,7 +167,7 @@ class PhilipsTimingInfo:
         try:
             header = pydicom.dcmread(img1path,stop_before_pixels = True)
         except:
-            header = dicom.read_file(img1path)
+            header = pydicom.dcmread(img1path, stop_before_pixels=True, force=True)
 
         self.studydate = header.StudyDate
 

--- a/DCE_IDandPhaseSelect/DCE_IDandPhaseSelect.py
+++ b/DCE_IDandPhaseSelect/DCE_IDandPhaseSelect.py
@@ -40,9 +40,11 @@ import numpy as np
 import pydicom
 
 def _pipEnsure(package):
+  import importlib
+  import slicer
   try:
-    import slicer.packaging
-    slicer.packaging.pip_ensure(package, requester="Breast_DCEMRI_FTV")
+    packaging = importlib.import_module('slicer.packaging')
+    packaging.pip_ensure(package, requester="Breast_DCEMRI_FTV")
   except (AttributeError, ImportError, ModuleNotFoundError):
     try:
       slicer.util.pip_install(package)

--- a/DCE_IDandPhaseSelect/DCE_IDandPhaseSelect.py
+++ b/DCE_IDandPhaseSelect/DCE_IDandPhaseSelect.py
@@ -75,6 +75,7 @@ import pathlib
 #7/27/2021: Start with Plugin folder import
 import Breast_DCEMRI_FTV_plugins1
 from Breast_DCEMRI_FTV_plugins1 import Get_header_info_all_manufacturer
+from Breast_DCEMRI_FTV_plugins1.Get_header_info_all_manufacturer import findDicomFilePaths
 from Breast_DCEMRI_FTV_plugins1 import read_DCE_images_to_numpy
 from Breast_DCEMRI_FTV_plugins1 import Exam_Ident_and_timing
 from Breast_DCEMRI_FTV_plugins1 import ident_gzipped_exam
@@ -320,143 +321,131 @@ class DCE_IDandPhaseSelectWidget(ScriptedLoadableModuleWidget):
       #6/28/2021: Read info from DICOM header instead of
       #directory for 'generic' exams with other directory structures
       folders = [directory for directory in os.listdir(self.exampath) if os.path.isdir(os.path.join(self.exampath,directory))]
-      dcm_folder_found = 0
       for i in range(len(folders)):
         curr_path = os.path.join(self.exampath,folders[i])
-        curr_files = [f for f in os.listdir(curr_path) if f.endswith('.dcm')]
-        curr_FILES = [f for f in os.listdir(curr_path) if f.endswith('.DCM')]
-        files_noext = [f for f in os.listdir(curr_path) if f.isdigit()]
+        dcm_paths = findDicomFilePaths(curr_path, minFiles=3)
+        if len(dcm_paths) == 0:
+          continue
 
-        if(len(curr_files) > 2):
-          dcm1path = os.path.join(curr_path,curr_files[0])
-          dcm_folder_found = 1
-
-        if(len(curr_FILES) > 2):
-          dcm1path = os.path.join(curr_path,curr_FILES[0])
-          dcm_folder_found = 1
-
-        if(len(files_noext) > 2):
-          dcm1path = os.path.join(curr_path,files_noext[0])
-          dcm_folder_found = 1
-
-        if(dcm_folder_found == 1):
-          hdr_dcm1 = pydicom.dcmread(dcm1path,stop_before_pixels = True)
+        dcm1path = dcm_paths[0]
+        hdr_dcm1 = pydicom.dcmread(dcm1path,stop_before_pixels = True)
+        try:
+          self.studystr = hdr_dcm1[0x12,0x10].value #Clinical Trial Sponsor Name
+        except:
           try:
-            self.studystr = hdr_dcm1[0x12,0x10].value #Clinical Trial Sponsor Name
+            self.studystr = hdr_dcm1[0x8,0x1030].value #Study Description
           except:
-            try:
-              self.studystr = hdr_dcm1[0x8,0x1030].value #Study Description
-            except:
-              self.studystr = 'Trial Name Unknown'
+            self.studystr = 'Trial Name Unknown'
 
+        try:
+          self.sitestr = hdr_dcm1[0x12,0x31].value #Clinical Trial Site Name
+        except:
           try:
-            self.sitestr = hdr_dcm1[0x12,0x31].value #Clinical Trial Site Name
+            self.sitestr = hdr_dcm1[0x8,0x80].value #Institution Name
           except:
-            try:
-              self.sitestr = hdr_dcm1[0x8,0x80].value #Institution Name
-            except:
-              self.sitestr = 'Site Unknown'
+            self.sitestr = 'Site Unknown'
 
-          try:
-            self.idstr = hdr_dcm1[0x12,0x40].value #Clinical Trial Subject ID
-          except:
-            self.idstr = 'ID Unknown'
+        try:
+          self.idstr = hdr_dcm1[0x12,0x40].value #Clinical Trial Subject ID
+        except:
+          self.idstr = 'ID Unknown'
 
-          try:
-            self.visitstr = hdr_dcm1[0x12,0x50].value #Clinical Trial Time Point ID
-            #7/4/2021: Try to use directory structure if visit number not found
-            #in Clinical Trial Time Point id header field
-            if('1' not in self.visitstr and '2' not in self.visitstr and '3' not in self.visitstr and '4' not in self.visitstr and '5' not in self.visitstr):
-              #6/29/2021: Default to 'Visit unknown',
-              #change this if visit is found in exampath
-              if(self.studystr == 'ispy_2022' or self.studystr == 'ispy2.2' or ('//researchfiles' in self.exampath and 'ispy_2022' in self.exampath)):
-                self.visitstr = 'Visit unknown'
-                if('v10' in self.exampath):
-                  self.visitstr = 'A0'
-              
-                if('v20' in self.exampath):
-                  self.visitstr = 'A3W'
-              
-                if('v25' in self.exampath):
-                  self.visitstr = 'A6W'
-              
-                if('v30' in self.exampath):
-                  self.visitstr = 'A12W'
+        try:
+          self.visitstr = hdr_dcm1[0x12,0x50].value #Clinical Trial Time Point ID
+          #7/4/2021: Try to use directory structure if visit number not found
+          #in Clinical Trial Time Point id header field
+          if('1' not in self.visitstr and '2' not in self.visitstr and '3' not in self.visitstr and '4' not in self.visitstr and '5' not in self.visitstr):
+            #6/29/2021: Default to 'Visit unknown',
+            #change this if visit is found in exampath
+            if(self.studystr == 'ispy_2022' or self.studystr == 'ispy2.2' or ('//researchfiles' in self.exampath and 'ispy_2022' in self.exampath)):
+              self.visitstr = 'Visit unknown'
+              if('v10' in self.exampath):
+                self.visitstr = 'A0'
 
-                if('v35' in self.exampath):
-                  self.visitstr = 'AC2'
+              if('v20' in self.exampath):
+                self.visitstr = 'A3W'
 
-                if('v40' in self.exampath):
-                  self.visitstr = 'S1'
-              
-                if('v71' in self.exampath):
-                  self.visitstr = 'B3W'
+              if('v25' in self.exampath):
+                self.visitstr = 'A6W'
 
-                if('v72' in self.exampath):
-                  self.visitstr = 'B6W'
+              if('v30' in self.exampath):
+                self.visitstr = 'A12W'
 
-                if('v73' in self.exampath):
-                  self.visitstr = 'B12W'
+              if('v35' in self.exampath):
+                self.visitstr = 'AC2'
 
-              else:
-                self.visitstr = 'Visit unknown'
-                if('v10' in self.exampath):
-                  self.visitstr = 'MR1'
-              
-                if('v20' in self.exampath):
-                  self.visitstr = 'MR2'
+              if('v40' in self.exampath):
+                self.visitstr = 'S1'
 
-                if('v30' in self.exampath):
-                  self.visitstr = 'MR3'
+              if('v71' in self.exampath):
+                self.visitstr = 'B3W'
 
-                if('v40' in self.exampath):
-                  self.visitstr = 'MR4'
+              if('v72' in self.exampath):
+                self.visitstr = 'B6W'
 
-          except:
-          #6/29/2021: Default to 'Visit unknown',
-          #change this is visit is found in exampath
-              if(self.studystr == 'ispy_2022' or self.studystr == 'ispy2.2' or ('//researchfiles' in self.exampath and 'ispy_2022' in self.exampath)):
-                self.visitstr = 'Visit unknown'
-                if('v10' in self.exampath):
-                  self.visitstr = 'A0'
-              
-                if('v20' in self.exampath):
-                  self.visitstr = 'A3W'
-              
-                if('v25' in self.exampath):
-                  self.visitstr = 'A6W'
-              
-                if('v30' in self.exampath):
-                  self.visitstr = 'A12W'
+              if('v73' in self.exampath):
+                self.visitstr = 'B12W'
 
-                if('v35' in self.exampath):
-                  self.visitstr = 'AC2'
+            else:
+              self.visitstr = 'Visit unknown'
+              if('v10' in self.exampath):
+                self.visitstr = 'MR1'
 
-                if('v40' in self.exampath):
-                  self.visitstr = 'S1'
-              
-                if('v71' in self.exampath):
-                  self.visitstr = 'B3W'
+              if('v20' in self.exampath):
+                self.visitstr = 'MR2'
 
-                if('v72' in self.exampath):
-                  self.visitstr = 'B6W'
+              if('v30' in self.exampath):
+                self.visitstr = 'MR3'
 
-                if('v73' in self.exampath):
-                  self.visitstr = 'B12W'
+              if('v40' in self.exampath):
+                self.visitstr = 'MR4'
 
-              else:
-                self.visitstr = 'Visit unknown'
-                if('v10' in self.exampath):
-                  self.visitstr = 'MR1'
-              
-                if('v20' in self.exampath):
-                  self.visitstr = 'MR2'
+        except:
+        #6/29/2021: Default to 'Visit unknown',
+        #change this is visit is found in exampath
+            if(self.studystr == 'ispy_2022' or self.studystr == 'ispy2.2' or ('//researchfiles' in self.exampath and 'ispy_2022' in self.exampath)):
+              self.visitstr = 'Visit unknown'
+              if('v10' in self.exampath):
+                self.visitstr = 'A0'
 
-                if('v30' in self.exampath):
-                  self.visitstr = 'MR3'
+              if('v20' in self.exampath):
+                self.visitstr = 'A3W'
 
-                if('v40' in self.exampath):
-                  self.visitstr = 'MR4'
+              if('v25' in self.exampath):
+                self.visitstr = 'A6W'
+
+              if('v30' in self.exampath):
+                self.visitstr = 'A12W'
+
+              if('v35' in self.exampath):
+                self.visitstr = 'AC2'
+
+              if('v40' in self.exampath):
+                self.visitstr = 'S1'
+
+              if('v71' in self.exampath):
+                self.visitstr = 'B3W'
+
+              if('v72' in self.exampath):
+                self.visitstr = 'B6W'
+
+              if('v73' in self.exampath):
+                self.visitstr = 'B12W'
+
+            else:
+              self.visitstr = 'Visit unknown'
+              if('v10' in self.exampath):
+                self.visitstr = 'MR1'
+
+              if('v20' in self.exampath):
+                self.visitstr = 'MR2'
+
+              if('v30' in self.exampath):
+                self.visitstr = 'MR3'
+
+              if('v40' in self.exampath):
+                self.visitstr = 'MR4'
+        break
 
     #7/26/2021: If this step fails, DICOMs in exam directory are compressed.
     try:

--- a/DCE_IDandPhaseSelect/DCE_IDandPhaseSelect.py
+++ b/DCE_IDandPhaseSelect/DCE_IDandPhaseSelect.py
@@ -37,11 +37,19 @@ from qt import *
 from slicer.ScriptedLoadableModule import *
 import logging
 import numpy as np
+import pydicom
+
+def _pipEnsure(package):
+  try:
+    import slicer.packaging
+    slicer.packaging.pip_ensure(package, requester="Breast_DCEMRI_FTV")
+  except AttributeError:
+    slicer.util.pip_install(package)
 
 try:
   import nibabel as nib
-except:
-  slicer.util.pip_install('nibabel')
+except ImportError:
+  _pipEnsure('nibabel')
   import nibabel as nib
 
 from vtk.util.numpy_support import vtk_to_numpy
@@ -50,18 +58,6 @@ from vtk.util import numpy_support
 #from scipy import signal
 import qt
 import re
-
-try:
-  import pydicom
-except:
-  slicer.util.pip_install('pydicom')
-  import pydicom
-
-try:
-  import dicom
-except:
-  slicer.util.pip_install('dicom')
-  import dicom
 
 import math
 
@@ -628,7 +624,7 @@ class DCE_IDandPhaseSelectWidget(ScriptedLoadableModuleWidget):
     self.autoIdCheckBox.stateChanged.connect(self.onApplyButton) #2/11/2021: connect checking the auto folder ID box to onApplyButton function
     self.manualIdCheckBox.stateChanged.connect(self.manualDCESelectMenu) #2/11/2021: connect checking the manual folder ID box to function
                                                                          #for creating (or removing) manual DCE folder selection menu.
-    self.manualSubmitButton.connect('clicked(bool)',self.onApplyButton)
+    self.manualSubmitButton.clicked.connect(self.onApplyButton)
 
     # Add vertical spacer
     self.layout.addStretch(1)

--- a/DCE_IDandPhaseSelect/DCE_IDandPhaseSelect.py
+++ b/DCE_IDandPhaseSelect/DCE_IDandPhaseSelect.py
@@ -43,8 +43,11 @@ def _pipEnsure(package):
   try:
     import slicer.packaging
     slicer.packaging.pip_ensure(package, requester="Breast_DCEMRI_FTV")
-  except AttributeError:
-    slicer.util.pip_install(package)
+  except (AttributeError, ImportError, ModuleNotFoundError):
+    try:
+      slicer.util.pip_install(package)
+    except Exception:
+      slicer.util.pip_install(f"--user {package}")
 
 try:
   import nibabel as nib

--- a/DCE_IDandPhaseSelect/DCE_IDandPhaseSelect.py
+++ b/DCE_IDandPhaseSelect/DCE_IDandPhaseSelect.py
@@ -328,6 +328,9 @@ class DCE_IDandPhaseSelectWidget(ScriptedLoadableModuleWidget):
           continue
 
         dcm1path = dcm_paths[0]
+        if not os.path.isfile(dcm1path):
+          continue
+
         hdr_dcm1 = pydicom.dcmread(dcm1path,stop_before_pixels = True)
         try:
           self.studystr = hdr_dcm1[0x12,0x10].value #Clinical Trial Sponsor Name

--- a/DCE_IDandPhaseSelect/DCE_IDandPhaseSelect.py
+++ b/DCE_IDandPhaseSelect/DCE_IDandPhaseSelect.py
@@ -97,7 +97,7 @@ from Breast_DCEMRI_FTV_plugins1 import gzip_gunzip_pyfuncs
 
 def _configureVolumeNodeForDisplay(volumeNode, rasToIjkMatrix):
   volumeNode.SetRASToIJKMatrix(rasToIjkMatrix)
-  slicer.modules.volumes.logic().CreateDefaultVolumeDisplayNodes(volumeNode)
+  volumeNode.CreateDefaultDisplayNodes()
   displayNode = volumeNode.GetDisplayNode()
   if displayNode:
     displayNode.SetAutoWindowLevel(True)

--- a/DCE_IDandPhaseSelect/DCE_IDandPhaseSelect.py
+++ b/DCE_IDandPhaseSelect/DCE_IDandPhaseSelect.py
@@ -95,6 +95,14 @@ from Breast_DCEMRI_FTV_plugins1 import gzip_gunzip_pyfuncs
 #If user loads other visits, this will have value of 0 for those visits so that
 #you don't save workspace for those visits.
 
+def _configureVolumeNodeForDisplay(volumeNode, rasToIjkMatrix):
+  volumeNode.SetRASToIJKMatrix(rasToIjkMatrix)
+  slicer.modules.volumes.logic().CreateDefaultVolumeDisplayNodes(volumeNode)
+  displayNode = volumeNode.GetDisplayNode()
+  if displayNode:
+    displayNode.SetAutoWindowLevel(True)
+  return volumeNode
+
 def loadPreEarlyLate(exampath,visitnum,orig,dce_folders_manual,dce_ind_manual,earlyadd,lateadd):
 
   #6/28/2021: Make this compatible with exams that don't use
@@ -163,7 +171,7 @@ def loadPreEarlyLate(exampath,visitnum,orig,dce_folders_manual,dce_ind_manual,ea
   adisp = np.transpose(a,(2,1,0)) #nii needs x,y,z to have same orientation as DICOM, but for numpy array you need to return to dimension order z,y,x
   precontrast_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScalarVolumeNode",prenodestr) #add this image to dropdown node with name precontrast
   slicer.util.updateVolumeFromArray(precontrast_node, adisp)
-  precontrast_node.SetRASToIJKMatrix(m)
+  _configureVolumeNodeForDisplay(precontrast_node, m)
 
   m1 = vtk.vtkMatrix4x4()
   precontrast_node.GetIJKToRASMatrix(m1)
@@ -193,7 +201,7 @@ def loadPreEarlyLate(exampath,visitnum,orig,dce_folders_manual,dce_ind_manual,ea
   bdisp = np.transpose(b,(2,1,0)) #nii needs x,y,z to have same orientation as DICOM, but for numpy array you need to return to dimension order z,y,x
   early_post_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScalarVolumeNode",earlynodestr) #add this image to dropdown node with name precontrast
   slicer.util.updateVolumeFromArray(early_post_node, bdisp)
-  early_post_node.SetRASToIJKMatrix(m)
+  _configureVolumeNodeForDisplay(early_post_node, m)
 
   progressBar.value = 75
   progressBar.labelText = 'Early post-contrast image loaded to Slicer'
@@ -218,7 +226,10 @@ def loadPreEarlyLate(exampath,visitnum,orig,dce_folders_manual,dce_ind_manual,ea
   cdisp = np.transpose(c,(2,1,0)) #nii needs x,y,z to have same orientation as DICOM, but for numpy array you need to return to dimension order z,y,x
   late_post_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScalarVolumeNode",latenodestr) #add this image to dropdown node with name precontrast
   slicer.util.updateVolumeFromArray(late_post_node, cdisp)
-  late_post_node.SetRASToIJKMatrix(m)
+  _configureVolumeNodeForDisplay(late_post_node, m)
+
+  slicer.util.setSliceViewerLayers(background=precontrast_node)
+  slicer.app.applicationLogic().FitSliceToAll()
 
   progressBar.value = 99
   progressBar.labelText = 'Late post-contrast image loaded to Slicer'

--- a/DCE_TumorMapProcess/Breast_DCEMRI_FTV_plugins2/compute_lps_to_rcs.py
+++ b/DCE_TumorMapProcess/Breast_DCEMRI_FTV_plugins2/compute_lps_to_rcs.py
@@ -22,7 +22,6 @@
 
 import os
 import pydicom
-import dicom
 import numpy as np
 import re
 
@@ -77,7 +76,7 @@ def computeAffineAndAffineInverse(exampath,prefoldernum,nslice,fsort):
     try:
         img1 = pydicom.dcmread(file1)
     except:
-        img1 = dicom.read_file(file1)
+        img1 = pydicom.dcmread(file1, force=True)
 
     img1_orient = img1[0x20,0x37] #Image Orientation (Patient)
     img1_orient = [float(i) for i in img1_orient] #convert from list of strings to list of floats (numeric)
@@ -117,7 +116,7 @@ def computeAffineAndAffineInverse(exampath,prefoldernum,nslice,fsort):
     try:
         imgN = pydicom.dcmread(fileN)
     except:
-        imgN = dicom.read_file(fileN)
+        imgN = pydicom.dcmread(fileN, force=True)
 
     imgN_pos = imgN[0x20,0x32] #Image Position (Patient) for last slice
     #Next 2 lines convert from header field with values to list of floats
@@ -242,7 +241,7 @@ def getVOIVoxelsFromInverseAffine(exampath,xmlfilepath,prefoldernum,nslice,fsort
     try:
         img1 = pydicom.dcmread(file1)
     except:
-        img1 = dicom.read_file(file1)
+        img1 = pydicom.dcmread(file1, force=True)
 
     voi_mask = np.zeros((int(img1.Rows),int(img1.Columns),len(files)))
     voi_mask[xs:xf,ys:yf,zs:zf] = 1

--- a/DCE_TumorMapProcess/Breast_DCEMRI_FTV_plugins2/ftv_plots.py
+++ b/DCE_TumorMapProcess/Breast_DCEMRI_FTV_plugins2/ftv_plots.py
@@ -63,8 +63,12 @@ def _loadReportLogo(logo_dir):
 
 def _asRgbUint8(image):
     import numpy as np
+    image = np.asarray(image)
     if image.ndim == 2:
         image = np.stack([image, image, image], axis=-1)
+    # ROI grayscale is 0-1 float; SER/ROI marks use 0-255 in the same array.
+    if np.issubdtype(image.dtype, np.floating):
+        image = np.where(image > 1.0, image, image * 255.0)
     return np.clip(image, 0, 255).astype(np.uint8)
 
 def createPDFreport(gzipped,path,savenamepdf,tempres,fsort,manufacturer,dce_folders,nslice,earlyPostContrastNum,latePostContrastNum, earlydiffmm, earlydiffss, latediffmm, latediffss, preimg3d,img3d,ser,tumor_mask,voi_mask,xs,xf,ys,yf,zs,zf,omitCount,omitradii,omitcenters,pct,pre_thresh,pethresh,minconnpix,aff_mat,ijkToRASmat,nodevisstr,window,level,idstr):
@@ -147,7 +151,7 @@ def createPDFreport(gzipped,path,savenamepdf,tempres,fsort,manufacturer,dce_fold
                     if ser_slc[r,c] > 1.75 and ser_slc[r,c]<=3:
                         img_wroi_sercolor[r,c] = [255,255,0]
 
-        return _asRgbUint8(img_wroi_sercolor)
+        return img_wroi_sercolor
 
 
 

--- a/DCE_TumorMapProcess/Breast_DCEMRI_FTV_plugins2/ftv_plots.py
+++ b/DCE_TumorMapProcess/Breast_DCEMRI_FTV_plugins2/ftv_plots.py
@@ -61,6 +61,11 @@ def _loadReportLogo(logo_dir):
 
     return None
 
+def _asRgbUint8(image):
+    if image.ndim == 2:
+        image = np.stack([image, image, image], axis=-1)
+    return np.clip(image, 0, 255).astype(np.uint8)
+
 def createPDFreport(gzipped,path,savenamepdf,tempres,fsort,manufacturer,dce_folders,nslice,earlyPostContrastNum,latePostContrastNum, earlydiffmm, earlydiffss, latediffmm, latediffss, preimg3d,img3d,ser,tumor_mask,voi_mask,xs,xf,ys,yf,zs,zf,omitCount,omitradii,omitcenters,pct,pre_thresh,pethresh,minconnpix,aff_mat,ijkToRASmat,nodevisstr,window,level,idstr):
     #note: although variable is called ser_colormap, may decide to use regular SER image instead so that colorbar shows true SER values
 
@@ -141,7 +146,7 @@ def createPDFreport(gzipped,path,savenamepdf,tempres,fsort,manufacturer,dce_fold
                     if ser_slc[r,c] > 1.75 and ser_slc[r,c]<=3:
                         img_wroi_sercolor[r,c] = [255,255,0]
 
-        return img_wroi_sercolor
+        return _asRgbUint8(img_wroi_sercolor)
 
 
 
@@ -667,7 +672,7 @@ def createPDFreport(gzipped,path,savenamepdf,tempres,fsort,manufacturer,dce_fold
     #top right
     a = fig.add_subplot(spec[0,2])
     if logo is not None:
-        imgplot = plt.imshow(logo)
+        imgplot = plt.imshow(_asRgbUint8(logo))
     plt.axis('off')
 
     #Edit 4/29/2020: Finalized orientation label letters on images
@@ -692,7 +697,7 @@ def createPDFreport(gzipped,path,savenamepdf,tempres,fsort,manufacturer,dce_fold
 
     #Sagittal cropped slice with SER colorization
     a = fig.add_subplot(spec[1,2])
-    imgplot = plt.imshow(img_sag_clr_crop,aspect=asp)
+    imgplot = plt.imshow(_asRgbUint8(img_sag_clr_crop),aspect=asp)
     txtplot = plt.text((img_sag_clr_crop.shape[1]/50),(img_sag_clr_crop.shape[0]/2),sagleftlbl,fontdict=font) # 1/50 through column range, 1/2 through row range of image
     txtplot = plt.text((47*img_sag_clr_crop.shape[1]/50),(img_sag_clr_crop.shape[0]/2),sagrightlbl,fontdict=font) # 47/50 through column range, 1/2 through row range of image
     txtplot = plt.text((img_sag_clr_crop.shape[1]/2),(5*img_sag_clr_crop.shape[0]/50),sagtoplbl,fontdict=font) #1/2 through column range, 5/50 through row range of image
@@ -719,7 +724,7 @@ def createPDFreport(gzipped,path,savenamepdf,tempres,fsort,manufacturer,dce_fold
     plt.axis('off')
     #Axial cropped slice with SER colorization
     a = fig.add_subplot(spec[2,2])
-    imgplot = plt.imshow(img_ax_clr_crop)
+    imgplot = plt.imshow(_asRgbUint8(img_ax_clr_crop))
     txtplot = plt.text((img_ax_clr_crop.shape[1]/50),(img_ax_clr_crop.shape[0]/2),axleftlbl,fontdict=font) #1/50 through column range, 1/2 through row range of image
     txtplot = plt.text((47*img_ax_clr_crop.shape[1]/50),(img_ax_clr_crop.shape[0]/2),axrightlbl,fontdict=font) #47/50 through column range, 1/2 through row range of image
     txtplot = plt.text((img_ax_clr_crop.shape[1]/2),(5*img_ax_clr_crop.shape[0]/50),axtoplbl,fontdict=font) #1/2 through column range, 5/50 through row range of image

--- a/DCE_TumorMapProcess/Breast_DCEMRI_FTV_plugins2/ftv_plots.py
+++ b/DCE_TumorMapProcess/Breast_DCEMRI_FTV_plugins2/ftv_plots.py
@@ -28,14 +28,7 @@ def createPDFreport(gzipped,path,savenamepdf,tempres,fsort,manufacturer,dce_fold
     #All of the figures (except ser colormap) are using 2nd post-contrast minus pre-contrast
     import slicer
     import matplotlib
-
-    try:
-        import wx
-    except:
-        slicer.util.pip_install('wxPython')
-        import wx
-
-    matplotlib.use('WXAgg')
+    matplotlib.use('Agg')
     import matplotlib.pyplot as plt
     import matplotlib.gridspec as gridspec
     import matplotlib.patches as mpatches
@@ -43,7 +36,6 @@ def createPDFreport(gzipped,path,savenamepdf,tempres,fsort,manufacturer,dce_fold
     import numpy as np
     from skimage import color
     import pydicom
-    import dicom
     import os
 
     import Breast_DCEMRI_FTV_plugins2
@@ -273,7 +265,7 @@ def createPDFreport(gzipped,path,savenamepdf,tempres,fsort,manufacturer,dce_fold
     try:
       pre_hdr1 = pydicom.dcmread(pre_img1path,stop_before_pixels = True)
     except:
-      pre_hdr1 = dicom.read_file(pre_img1path)
+      pre_hdr1 = pydicom.dcmread(pre_img1path, stop_before_pixels=True, force=True)
 
 
     #edit 6/11/2020: Split by single vs multi folder DCE instead of non-Philips vs Philips
@@ -302,7 +294,7 @@ def createPDFreport(gzipped,path,savenamepdf,tempres,fsort,manufacturer,dce_fold
     try:
         earlyslice1hdr = pydicom.dcmread(earlyslice1path,stop_before_pixels = True)
     except:
-        earlyslice1hdr = dicom.read_file(earlyslice1path)
+        earlyslice1hdr = pydicom.dcmread(earlyslice1path, stop_before_pixels=True, force=True)
 
     #aspect ratio for sagittal images
     #Edit 5/11/2020: Using aff_mat[2,2] instead of hdr.SpacingBetweenSlices to allow aspect ratio definition for Siemens scanner images
@@ -485,7 +477,7 @@ def createPDFreport(gzipped,path,savenamepdf,tempres,fsort,manufacturer,dce_fold
     try:
         lateslice1hdr = pydicom.dcmread(lateslice1path,stop_before_pixels = True)
     except:
-        lateslice1hdr = dicom.read_file(lateslice1path)
+        lateslice1hdr = pydicom.dcmread(lateslice1path, stop_before_pixels=True, force=True)
 
     font = {'color': 'yellow','size': 15} #font dictionary settings for orientation labels on images
     fontfov = {'color': 'yellow', 'size': 8} #font dictionary settings for FOV labels on images

--- a/DCE_TumorMapProcess/Breast_DCEMRI_FTV_plugins2/ftv_plots.py
+++ b/DCE_TumorMapProcess/Breast_DCEMRI_FTV_plugins2/ftv_plots.py
@@ -62,6 +62,7 @@ def _loadReportLogo(logo_dir):
     return None
 
 def _asRgbUint8(image):
+    import numpy as np
     if image.ndim == 2:
         image = np.stack([image, image, image], axis=-1)
     return np.clip(image, 0, 255).astype(np.uint8)

--- a/DCE_TumorMapProcess/Breast_DCEMRI_FTV_plugins2/ftv_plots.py
+++ b/DCE_TumorMapProcess/Breast_DCEMRI_FTV_plugins2/ftv_plots.py
@@ -22,6 +22,45 @@
 #images from the MR exam, and other relevant information such as
 #imaging site, visit number, and exam date.
 
+def _loadReportLogo(logo_dir):
+    import os
+    import numpy as np
+    import cv2
+    import matplotlib.image as mpimg
+    import slicer
+
+    candidates = []
+    for name in ('3DSlicerLogo.png', '3DSlicerLogo.PNG'):
+        candidates.append(os.path.join(logo_dir, name))
+    try:
+        slicer_home = slicer.app.slicerHome
+        for name in ('3DSlicerLogo.png', '3DSlicerLogo.PNG', 'Slicer.png'):
+            candidates.append(os.path.join(slicer_home, name))
+    except AttributeError:
+        pass
+
+    for logo_path in candidates:
+        if not os.path.isfile(logo_path):
+            continue
+
+        logo = cv2.imread(logo_path, cv2.IMREAD_COLOR)
+        if logo is not None and logo.size > 0:
+            return cv2.cvtColor(logo, cv2.COLOR_BGR2RGB)
+
+        try:
+            logo = mpimg.imread(logo_path)
+            if logo is None or getattr(logo, 'dtype', None) == object:
+                continue
+            if logo.dtype in (np.float32, np.float64):
+                logo = np.clip(logo * 255.0, 0, 255).astype(np.uint8)
+            if len(logo.shape) == 3 and logo.shape[2] == 4:
+                logo = logo[:, :, :3]
+            return logo
+        except Exception:
+            continue
+
+    return None
+
 def createPDFreport(gzipped,path,savenamepdf,tempres,fsort,manufacturer,dce_folders,nslice,earlyPostContrastNum,latePostContrastNum, earlydiffmm, earlydiffss, latediffmm, latediffss, preimg3d,img3d,ser,tumor_mask,voi_mask,xs,xf,ys,yf,zs,zf,omitCount,omitradii,omitcenters,pct,pre_thresh,pethresh,minconnpix,aff_mat,ijkToRASmat,nodevisstr,window,level,idstr):
     #note: although variable is called ser_colormap, may decide to use regular SER image instead so that colorbar shows true SER values
 
@@ -585,8 +624,9 @@ def createPDFreport(gzipped,path,savenamepdf,tempres,fsort,manufacturer,dce_fold
     #The full path to ftv_plots.py is
     #automatically stored in __file__ so I'm using that.
     pathtofunc,funcname = os.path.split(os.path.realpath(__file__))
-    logo_path = os.path.join(pathtofunc,'3DSlicerLogo.png')
-    logo = cv2.imread(logo_path)
+    logo = _loadReportLogo(pathtofunc)
+    if logo is None:
+        print("Report logo not found; continuing without logo image.")
 #------------------------Writing txt file--------------------------------------#
     txt_file = open(savenametxt, "w+")
 
@@ -626,7 +666,8 @@ def createPDFreport(gzipped,path,savenamepdf,tempres,fsort,manufacturer,dce_fold
     plt.axis('off')
     #top right
     a = fig.add_subplot(spec[0,2])
-    imgplot = plt.imshow(logo)
+    if logo is not None:
+        imgplot = plt.imshow(logo)
     plt.axis('off')
 
     #Edit 4/29/2020: Finalized orientation label letters on images

--- a/DCE_TumorMapProcess/Breast_DCEMRI_FTV_plugins2/gzip_gunzip_pyfuncs.py
+++ b/DCE_TumorMapProcess/Breast_DCEMRI_FTV_plugins2/gzip_gunzip_pyfuncs.py
@@ -151,7 +151,7 @@ def gunzipAllFilesDCE(exampath,dce_folder):
     #Edit 2/4/2021: Only do this if all of the DICOMs are gzipped
     if(len(filesdcmgz) == len(files)):
         cmd_base = r'"C:\Program Files\7-Zip\7z" x '
-        cmd_7z = cmd_base + dcegzipped_paths[0] + '\*' + ' -o' + dcegunzip_dest_paths[0]
+        cmd_7z = cmd_base + dcegzipped_paths[0] + r'\*' + ' -o' + dcegunzip_dest_paths[0]
         os.system(cmd_7z) #execute above command
     else:
         #Edit 2/4/2021: If all the DICOMs are not gzipped, use copy_tree
@@ -171,7 +171,7 @@ def gunzipAllFilesDCE(exampath,dce_folder):
             #Edit 2/4/2021: Once you've looped through the files to ensure that all are gzipped,
             #gunzip all of them to the new gunzipped directory.
             cmd_base = r'"C:\Program Files\7-Zip\7z" x '
-            cmd_7z = cmd_base + dcegzipped_paths[0] + '\*' + ' -o' + dcegunzip_dest_paths[0]
+            cmd_7z = cmd_base + dcegzipped_paths[0] + r'\*' + ' -o' + dcegunzip_dest_paths[0]
             os.system(cmd_7z) #execute above command
 
     return

--- a/DCE_TumorMapProcess/Breast_DCEMRI_FTV_plugins2/read_DCE_images_to_numpy.py
+++ b/DCE_TumorMapProcess/Breast_DCEMRI_FTV_plugins2/read_DCE_images_to_numpy.py
@@ -26,56 +26,61 @@ import re
 import os
 import slicer
 import vtk
-import SimpleITK as sitk
-import sitkUtils
 
-def _dicomFileNamesInDirectory(path):
-    names = []
-    for f in os.listdir(path):
-        full = os.path.join(path, f)
-        if not os.path.isfile(full):
-            continue
-        if f.endswith('.dcm') or f.endswith('.DCM') or f.isdigit():
-            names.append(f)
-    return sorted(names)
+def _dicomDatabaseIsOpen():
+    db = slicer.dicomDatabase
+    if db is None:
+        return False
+    try:
+        return db.database().isOpen()
+    except AttributeError:
+        return False
 
-def _dicomSeriesFileNamesInDirectory(path):
-    series_ids = sitk.ImageSeriesReader.GetGDCMSeriesIDs(path)
-    if len(series_ids) > 0:
-        return list(sitk.ImageSeriesReader.GetGDCMSeriesFileNames(path, series_ids[0]))
-    return addFullPathToFileList(path, _dicomFileNamesInDirectory(path))
+def _ensureDicomDatabaseOpen():
+    if _dicomDatabaseIsOpen():
+        return
 
-def _dicomSeriesToNumpy(dicom_names):
-    reader = sitk.ImageSeriesReader()
-    reader.SetFileNames(list(dicom_names))
-    sitk_image = reader.Execute()
-    volume = sitkUtils.PushVolumeToSlicer(sitk_image)
+    db = slicer.dicomDatabase
+    if db is None:
+        return
 
+    databaseFilename = None
+    try:
+        databaseFilename = slicer.app.applicationLogic().GetDICOMDatabaseFilename()
+    except AttributeError:
+        pass
+
+    if databaseFilename:
+        db.openDatabase(databaseFilename)
+        if _dicomDatabaseIsOpen():
+            return
+
+    db_dir = os.path.join(os.path.expanduser('~'), '.slicer', 'FTV_DICOM')
+    os.makedirs(db_dir, exist_ok=True)
+    db.openDatabase(os.path.join(db_dir, 'DICOM.db'))
+
+def _loadDicomSeriesVolume(dicom_names):
+    _ensureDicomDatabaseOpen()
+    plugin = slicer.modules.dicomPlugins['DICOMScalarVolumePlugin']()
+    loadables = plugin.examine([dicom_names])
+    if not loadables:
+        raise RuntimeError('DICOMScalarVolumePlugin found no loadable series')
+    return plugin.load(loadables[0])
+
+def _volumeToNumpy(volume):
     m = vtk.vtkMatrix4x4()
     volume.GetRASToIJKMatrix(m)
 
     npimg = slicer.util.arrayFromVolume(volume)
     slicer.mrmlScene.RemoveNode(volume)
-    return m, npimg
-
-def _volumeArrayToNumpy(m, npimg, to_float64=True):
     npimg = np.transpose(npimg, (2, 1, 0))
-    if to_float64:
-        npimg = npimg.astype('float64')
-    else:
-        try:
-            npimg = npimg.astype('float64')
-        except:
-            try:
-                npimg = npimg.astype('float32')
-            except:
-                npimg = npimg.astype('int8')
     return m, npimg
 
 #Philips correct z-order of slices
 #Edit 6/10/2020: By checking both OHSC and UChic exams from Philips, I realized that the routine from
 #multivolume_folder_sort always leads to the correct orientation in the report, regardless of if the
 #filenames are in reverse order or not -- This is for Philips only
+
 
 #GE & Siemens correct z-order of slices
 #Update--It appears that regular, increasing order of Slice Location works for RMH exams, but not for UCSD exams
@@ -86,14 +91,17 @@ def _volumeArrayToNumpy(m, npimg, to_float64=True):
 #4/3/2020: New version of readInputToNumpy using SimpleITK
 #Edit 6/16/2020: Incorporate Andrey's suggested method of reading DICOM series into Slicer
 def readInputToNumpy(path):
-    dicom_names = _dicomSeriesFileNamesInDirectory(path)
-    m, npimg = _dicomSeriesToNumpy(dicom_names)
+    dicom_names = os.listdir(path)
+    dicom_names = addFullPathToFileList(path, dicom_names)
+
+    volume = _loadDicomSeriesVolume(dicom_names)
+    m, npimg = _volumeToNumpy(volume)
     print("image dimensions")
     print(np.shape(npimg))
     print("image min and max after arrayFromVolume")
     print(np.amin(npimg))
     print(np.amax(npimg))
-    m, npimg = _volumeArrayToNumpy(m, npimg, to_float64=True)
+    npimg = npimg.astype('float64')
     print("image min and max after float64 conversion")
     print(np.amin(npimg))
     print(np.amax(npimg))
@@ -116,7 +124,6 @@ def earlyOrLateImgSelect(postContrastNum,dce_folders,exampath):
     a = readInputToNumpy(path)
     return a
 
-
 #For this function, need loop to concatenate full path to filename at each iteration
 def readPhilipsImageToNumpy(exampath,dce_folders,fsort,postContrastNum):
 
@@ -130,7 +137,7 @@ def readPhilipsImageToNumpy(exampath,dce_folders,fsort,postContrastNum):
         dcepath = os.path.join(exampath,str(dce_folders[0]))
 
     dicom_names = fsort[postContrastNum][:]
-    dicom_names = addFullPathToFileList(dcepath,dicom_names) #call function for converting list of DCM filenames to list of DCM file names with path included
+    dicom_names = addFullPathToFileList(dcepath,dicom_names)
 
     #7/20/2021: If image dimensions > 700 x 700 x 200, cut off
     #20 slices from each side. Hopefully this prevents numpy
@@ -143,12 +150,21 @@ def readPhilipsImageToNumpy(exampath,dce_folders,fsort,postContrastNum):
     except:
         print("Not checking image size, therefore will not remove slices.")
 
-    m, npimg = _dicomSeriesToNumpy(dicom_names)
+    volume = _loadDicomSeriesVolume(dicom_names)
+    m, npimg = _volumeToNumpy(volume)
     print("image min and max after arrayFromVolume")
     print(dcepath)
     print(np.amin(npimg))
     print(np.amax(npimg))
-    return _volumeArrayToNumpy(m, npimg, to_float64=False)
+    try:
+        npimg = npimg.astype('float64')
+    except:
+        try:
+            npimg = npimg.astype('float32')
+        except:
+            npimg = npimg.astype('int8')
+
+    return m, npimg
 
 #Wrote this function for quickly converting list of DCM filenames to list of DCM file names with path included
 def addFullPathToFileList(path,files):
@@ -157,4 +173,3 @@ def addFullPathToFileList(path,files):
         fullfilei = os.path.join(path,filei)
         files[i] = fullfilei
     return files
-

--- a/DCE_TumorMapProcess/Breast_DCEMRI_FTV_plugins2/read_DCE_images_to_numpy.py
+++ b/DCE_TumorMapProcess/Breast_DCEMRI_FTV_plugins2/read_DCE_images_to_numpy.py
@@ -22,7 +22,6 @@
 
 import numpy as np
 import pydicom
-import dicom
 import re
 import os
 import slicer

--- a/DCE_TumorMapProcess/Breast_DCEMRI_FTV_plugins2/read_DCE_images_to_numpy.py
+++ b/DCE_TumorMapProcess/Breast_DCEMRI_FTV_plugins2/read_DCE_images_to_numpy.py
@@ -26,6 +26,51 @@ import re
 import os
 import slicer
 import vtk
+import SimpleITK as sitk
+import sitkUtils
+
+def _dicomFileNamesInDirectory(path):
+    names = []
+    for f in os.listdir(path):
+        full = os.path.join(path, f)
+        if not os.path.isfile(full):
+            continue
+        if f.endswith('.dcm') or f.endswith('.DCM') or f.isdigit():
+            names.append(f)
+    return sorted(names)
+
+def _dicomSeriesFileNamesInDirectory(path):
+    series_ids = sitk.ImageSeriesReader.GetGDCMSeriesIDs(path)
+    if len(series_ids) > 0:
+        return list(sitk.ImageSeriesReader.GetGDCMSeriesFileNames(path, series_ids[0]))
+    return addFullPathToFileList(path, _dicomFileNamesInDirectory(path))
+
+def _dicomSeriesToNumpy(dicom_names):
+    reader = sitk.ImageSeriesReader()
+    reader.SetFileNames(list(dicom_names))
+    sitk_image = reader.Execute()
+    volume = sitkUtils.PushVolumeToSlicer(sitk_image)
+
+    m = vtk.vtkMatrix4x4()
+    volume.GetRASToIJKMatrix(m)
+
+    npimg = slicer.util.arrayFromVolume(volume)
+    slicer.mrmlScene.RemoveNode(volume)
+    return m, npimg
+
+def _volumeArrayToNumpy(m, npimg, to_float64=True):
+    npimg = np.transpose(npimg, (2, 1, 0))
+    if to_float64:
+        npimg = npimg.astype('float64')
+    else:
+        try:
+            npimg = npimg.astype('float64')
+        except:
+            try:
+                npimg = npimg.astype('float32')
+            except:
+                npimg = npimg.astype('int8')
+    return m, npimg
 
 #Philips correct z-order of slices
 #Edit 6/10/2020: By checking both OHSC and UChic exams from Philips, I realized that the routine from
@@ -41,28 +86,14 @@ import vtk
 #4/3/2020: New version of readInputToNumpy using SimpleITK
 #Edit 6/16/2020: Incorporate Andrey's suggested method of reading DICOM series into Slicer
 def readInputToNumpy(path):
-    #Edit 6/16/2020: os.listdir and adding full path may be faster
-    dicom_names = os.listdir(path)
-    dicom_names = addFullPathToFileList(path,dicom_names) #call function for converting list of DCM filenames to list of DCM file names with path included
-
-    plugin = slicer.modules.dicomPlugins['DICOMScalarVolumePlugin']()
-    loadables = plugin.examine([dicom_names])
-    volume = plugin.load(loadables[0])
-
-    #store RASToIJKMatrix in m so that you can use this to correct output images' orientations
-    m = vtk.vtkMatrix4x4()
-    volume.GetRASToIJKMatrix(m)
-
-    npimg = slicer.util.arrayFromVolume(volume)
+    dicom_names = _dicomSeriesFileNamesInDirectory(path)
+    m, npimg = _dicomSeriesToNumpy(dicom_names)
     print("image dimensions")
     print(np.shape(npimg))
     print("image min and max after arrayFromVolume")
     print(np.amin(npimg))
     print(np.amax(npimg))
-    slicer.mrmlScene.RemoveNode(volume) #this is how to prevent "unnamed volume ..." from staying in slicer window
-    npimg = np.transpose(npimg,(2,1,0)) #edit 4/27/2020: using dimension order x,y,z gives same orientation as input DICOM (original numpy one is z,y,x)
-    #npimg = np.flip(npimg,2) #apparently slicer method of reading DICOM series always reverses slice order from what we want, so add this flip
-    npimg = npimg.astype('float64') #convert to float64 to avoid dynamic range issues when calculating PE and SER
+    m, npimg = _volumeArrayToNumpy(m, npimg, to_float64=True)
     print("image min and max after float64 conversion")
     print(np.amin(npimg))
     print(np.amax(npimg))
@@ -112,32 +143,12 @@ def readPhilipsImageToNumpy(exampath,dce_folders,fsort,postContrastNum):
     except:
         print("Not checking image size, therefore will not remove slices.")
 
-    plugin = slicer.modules.dicomPlugins['DICOMScalarVolumePlugin']()
-    loadables = plugin.examine([dicom_names])
-    volume = plugin.load(loadables[0])
-
-    #store RASToIJKMatrix in m so that you can use this to correct output images' orientations
-    m = vtk.vtkMatrix4x4()
-    volume.GetRASToIJKMatrix(m)
-
-    npimg = slicer.util.arrayFromVolume(volume)
+    m, npimg = _dicomSeriesToNumpy(dicom_names)
     print("image min and max after arrayFromVolume")
     print(dcepath)
     print(np.amin(npimg))
     print(np.amax(npimg))
-    slicer.mrmlScene.RemoveNode(volume) #this is how to prevent "unnamed volume ..." from staying in slicer window
-
-    npimg = np.transpose(npimg,(2,1,0)) #edit 4/27/2020: using dimension order x,y,z gives same orientation as input DICOM (original numpy one is z,y,x)
-    #npimg = np.flip(npimg,2) #apparently slicer method of reading DICOM series always reverses slice order from what we want, so add this flip
-    try:
-        npimg = npimg.astype('float64') #convert to float64 to avoid dynamic range issues when calculating PE and SER
-    except:
-        try:
-            npimg = npimg.astype('float32')
-        except:
-            npimg = npimg.astype('int8')
-
-    return m, npimg
+    return _volumeArrayToNumpy(m, npimg, to_float64=False)
 
 #Wrote this function for quickly converting list of DCM filenames to list of DCM file names with path included
 def addFullPathToFileList(path,files):

--- a/DCE_TumorMapProcess/DCE_TumorMapProcess.py
+++ b/DCE_TumorMapProcess/DCE_TumorMapProcess.py
@@ -34,65 +34,37 @@ import vtk, qt, ctk, slicer
 from vtk.util.numpy_support import vtk_to_numpy
 from vtk.util import numpy_support
 from slicer.ScriptedLoadableModule import *
-from slicer.util import VTKObservationMixin
 import numpy as np
-
-try:
-  import pydicom
-except:
-  slicer.util.pip_install('pydicom')
-  import pydicom
-
-try:
-  import dicom
-except:
-  slicer.util.pip_install('dicom')
-  import dicom
+import pydicom
 
 import time
 import datetime
-
-try:
-  import nibabel as nib
-except:
-  slicer.util.pip_install('nibabel')
-  import nibabel as nib
-
-try:
-  import cv2
-except:
-  slicer.util.pip_install('opencv-python')
-  import cv2
-
-try:
-  import nrrd
-except:
-  slicer.util.pip_install('pynrrd')
-  import nrrd
-
 import sys
 import pickle
 import pathlib
 
-try:
-  import yattag
-except:
-  slicer.util.pip_install('yattag')
-  import yattag
+def _pipEnsure(package):
+  try:
+    import slicer.packaging
+    slicer.packaging.pip_ensure(package, requester="Breast_DCEMRI_FTV")
+  except AttributeError:
+    slicer.util.pip_install(package)
 
-try:
-  import matplotlib
-except:
-  slicer.util.pip_install('matplotlib')
-  import matplotlib
+def _importOptional(package, moduleName=None):
+  moduleName = moduleName or package
+  try:
+    return __import__(moduleName)
+  except ImportError:
+    _pipEnsure(package)
+    return __import__(moduleName)
 
+nib = _importOptional('nibabel')
+cv2 = _importOptional('cv2', 'cv2')
+nrrd = _importOptional('pynrrd', 'nrrd')
+yattag = _importOptional('yattag')
+matplotlib = _importOptional('matplotlib')
 import matplotlib.pyplot as plt
-
-try:
-  import skimage
-except:
-  slicer.util.pip_install('scikit-image')
-  import skimage
+skimage = _importOptional('scikit-image', 'skimage')
 
 #imports of my functions
 #7/27/2021: Replace individual imports with Plugin folder import
@@ -792,10 +764,9 @@ class DCE_TumorMapProcessWidget(ScriptedLoadableModuleWidget):
     #Call function that returns RAS coordinate center and radius give input volume and IJK coordinate center and radius
     roicenter_RAS, roiradius_RAS = IJKToRASFunc(roicenter,roiradius,inputVolume)
 
-    self.roi = slicer.vtkMRMLMarkupsLineNode()
-    self.roi.SetXYZ(roicenter_RAS)
-    self.roi.SetRadiusXYZ(roiradius_RAS)
-    slicer.mrmlScene.AddNode(self.roi)
+    self.roi = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsROINode")
+    self.roi.SetXYZ(roicenter_RAS[0], roicenter_RAS[1], roicenter_RAS[2])
+    self.roi.SetRadiusXYZ(roiradius_RAS[0], roiradius_RAS[1], roiradius_RAS[2])
 
     self.switchimage = True #variable to prevent calling of adjust window level function while changing image
                             #displayed from dropdown menu
@@ -859,11 +830,11 @@ class DCE_TumorMapProcessWidget(ScriptedLoadableModuleWidget):
     self.omitCount = 0
 
     #5 omit regions max. These are stored in distinct attributes of widget class object
-    self.omit1 = slicer.vtkMRMLMarkupsLineNode()
-    self.omit2 = slicer.vtkMRMLMarkupsLineNode()
-    self.omit3 = slicer.vtkMRMLMarkupsLineNode()
-    self.omit4 = slicer.vtkMRMLMarkupsLineNode()
-    self.omit5 = slicer.vtkMRMLMarkupsLineNode()
+    self.omit1 = slicer.vtkMRMLMarkupsROINode()
+    self.omit2 = slicer.vtkMRMLMarkupsROINode()
+    self.omit3 = slicer.vtkMRMLMarkupsROINode()
+    self.omit4 = slicer.vtkMRMLMarkupsROINode()
+    self.omit5 = slicer.vtkMRMLMarkupsROINode()
 
     # Save Region to File Button
     #
@@ -988,11 +959,11 @@ class DCE_TumorMapProcessWidget(ScriptedLoadableModuleWidget):
     self.axchkbox.stateChanged.connect(self.showAxialMIPFromNode)
     self.sagchkbox.stateChanged.connect(self.showSagittalMIPFromNode)
     self.segmentLesionCheckBox.stateChanged.connect(self.segmentLesion) #Edit 7/24/2020: This is now a checkbox option
-    self.applyButton.connect('clicked(bool)', self.onApplyButton)
-    self.addOmitButton.connect('clicked(bool)',self.addOmitRegion)
-    self.importROIButton.connect('clicked(bool)',self.importROIFromFile)
-    self.saveRegionButton.connect('clicked(bool)',self.saveRegionToXML)
-    self.goToROICenterButton.connect('clicked(bool)',self.goToROICenter)
+    self.applyButton.clicked.connect(self.onApplyButton)
+    self.addOmitButton.clicked.connect(self.addOmitRegion)
+    self.importROIButton.clicked.connect(self.importROIFromFile)
+    self.saveRegionButton.clicked.connect(self.saveRegionToXML)
+    self.goToROICenterButton.clicked.connect(self.goToROICenter)
     self.inputSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.onSelect)
 
     #Call function to update text giving axial slice position whenever red slice position is adjusted
@@ -2298,7 +2269,7 @@ class DCE_TumorMapProcessWidget(ScriptedLoadableModuleWidget):
         try:
           pre_hdr1 = pydicom.dcmread(pre_img1path,stop_before_pixels = True)
         except:
-          pre_hdr1 = dicom.read_file(pre_img1path)
+          pre_hdr1 = pydicom.dcmread(pre_img1path,stop_before_pixels = True,force=True)
 
         voxsize_mm3 = float(pre_hdr1.PixelSpacing[0])*float(pre_hdr1.PixelSpacing[1])*float(abs(self.aff_mat[2,2])) #voxel size in mm^3
 

--- a/DCE_TumorMapProcess/DCE_TumorMapProcess.py
+++ b/DCE_TumorMapProcess/DCE_TumorMapProcess.py
@@ -44,9 +44,11 @@ import pickle
 import pathlib
 
 def _pipEnsure(package):
+  import importlib
+  import slicer
   try:
-    import slicer.packaging
-    slicer.packaging.pip_ensure(package, requester="Breast_DCEMRI_FTV")
+    packaging = importlib.import_module('slicer.packaging')
+    packaging.pip_ensure(package, requester="Breast_DCEMRI_FTV")
   except (AttributeError, ImportError, ModuleNotFoundError):
     try:
       slicer.util.pip_install(package)

--- a/DCE_TumorMapProcess/DCE_TumorMapProcess.py
+++ b/DCE_TumorMapProcess/DCE_TumorMapProcess.py
@@ -70,6 +70,16 @@ def _ensureVolumeDisplayNode(volumeNode):
     volumeNode.CreateDefaultDisplayNodes()
   return volumeNode.GetDisplayNode()
 
+def _configureMarkupsROIDisplay(markupsNode):
+  if markupsNode is None:
+    return
+  markupsNode.CreateDefaultDisplayNodes()
+  displayNode = markupsNode.GetDisplayNode()
+  if displayNode is None:
+    return
+  displayNode.SetFillVisibility(False)
+  displayNode.SetFillOpacity(0.0)
+
 nib = _importOptional('nibabel')
 cv2 = _importOptional('cv2', 'cv2')
 nrrd = _importOptional('pynrrd', 'nrrd')
@@ -786,6 +796,7 @@ class DCE_TumorMapProcessWidget(ScriptedLoadableModuleWidget):
     self.roi = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsROINode")
     self.roi.SetXYZ(roicenter_RAS[0], roicenter_RAS[1], roicenter_RAS[2])
     self.roi.SetRadiusXYZ(roiradius_RAS[0], roiradius_RAS[1], roiradius_RAS[2])
+    _configureMarkupsROIDisplay(self.roi)
 
     self.switchimage = True #variable to prevent calling of adjust window level function while changing image
                             #displayed from dropdown menu
@@ -1832,6 +1843,7 @@ class DCE_TumorMapProcessWidget(ScriptedLoadableModuleWidget):
         self.omit1.SetXYZ(roicenter_RAS)
         self.omit1.SetRadiusXYZ(omitradius_RAS)
         slicer.mrmlScene.AddNode(self.omit1)
+        _configureMarkupsROIDisplay(self.omit1)
         slicer.util.resetSliceViews()
       else:
         self.omitCount = self.omitCount - 1
@@ -1841,6 +1853,7 @@ class DCE_TumorMapProcessWidget(ScriptedLoadableModuleWidget):
         self.omit2.SetXYZ(roicenter_RAS)
         self.omit2.SetRadiusXYZ(omitradius_RAS)
         slicer.mrmlScene.AddNode(self.omit2)
+        _configureMarkupsROIDisplay(self.omit2)
         slicer.util.resetSliceViews()
       else:
         self.omitCount = self.omitCount - 1
@@ -1851,6 +1864,7 @@ class DCE_TumorMapProcessWidget(ScriptedLoadableModuleWidget):
         self.omit3.SetXYZ(roicenter_RAS)
         self.omit3.SetRadiusXYZ(omitradius_RAS)
         slicer.mrmlScene.AddNode(self.omit3)
+        _configureMarkupsROIDisplay(self.omit3)
         slicer.util.resetSliceViews()
       else:
         self.omitCount = self.omitCount - 1
@@ -1861,6 +1875,7 @@ class DCE_TumorMapProcessWidget(ScriptedLoadableModuleWidget):
         self.omit4.SetXYZ(roicenter_RAS)
         self.omit4.SetRadiusXYZ(omitradius_RAS)
         slicer.mrmlScene.AddNode(self.omit4)
+        _configureMarkupsROIDisplay(self.omit4)
         slicer.util.resetSliceViews()
       else:
         self.omitCount = self.omitCount - 1
@@ -1871,6 +1886,7 @@ class DCE_TumorMapProcessWidget(ScriptedLoadableModuleWidget):
         self.omit5.SetXYZ(roicenter_RAS)
         self.omit5.SetRadiusXYZ(omitradius_RAS)
         slicer.mrmlScene.AddNode(self.omit5)
+        _configureMarkupsROIDisplay(self.omit5)
         slicer.util.resetSliceViews()
       else:
         self.omitCount = self.omitCount - 1
@@ -2036,6 +2052,7 @@ class DCE_TumorMapProcessWidget(ScriptedLoadableModuleWidget):
     #position from xml file
     self.roi.SetXYZ(roicenter)
     self.roi.SetRadiusXYZ(roiradius)
+    _configureMarkupsROIDisplay(self.roi)
 
     #7/16/2021: Before proceeding to check xml file for omits,
     #remove any omits that may already be in the scene.
@@ -2081,26 +2098,31 @@ class DCE_TumorMapProcessWidget(ScriptedLoadableModuleWidget):
           self.omit1.SetXYZ(curr_center)
           self.omit1.SetRadiusXYZ(curr_radius)
           slicer.mrmlScene.AddNode(self.omit1)
+          _configureMarkupsROIDisplay(self.omit1)
 
         if self.omitCount == 2:
           self.omit2.SetXYZ(curr_center)
           self.omit2.SetRadiusXYZ(curr_radius)
           slicer.mrmlScene.AddNode(self.omit2)
+          _configureMarkupsROIDisplay(self.omit2)
 
         if self.omitCount == 3:
           self.omit3.SetXYZ(curr_center)
           self.omit3.SetRadiusXYZ(curr_radius)
           slicer.mrmlScene.AddNode(self.omit3)
+          _configureMarkupsROIDisplay(self.omit3)
 
         if self.omitCount == 4:
           self.omit4.SetXYZ(curr_center)
           self.omit4.SetRadiusXYZ(curr_radius)
           slicer.mrmlScene.AddNode(self.omit4)
+          _configureMarkupsROIDisplay(self.omit4)
 
         if self.omitCount == 5:
           self.omit5.SetXYZ(curr_center)
           self.omit5.SetRadiusXYZ(curr_radius)
           slicer.mrmlScene.AddNode(self.omit5)
+          _configureMarkupsROIDisplay(self.omit5)
 
     #Edit 7/31/2020: Set red and yellow slice positions to center axial and sagittal slices of ROI
     inputVolume = self.inputSelector.currentNode()

--- a/DCE_TumorMapProcess/DCE_TumorMapProcess.py
+++ b/DCE_TumorMapProcess/DCE_TumorMapProcess.py
@@ -67,7 +67,7 @@ def _ensureVolumeDisplayNode(volumeNode):
   if volumeNode is None:
     return None
   if volumeNode.GetDisplayNode() is None:
-    slicer.modules.volumes.logic().CreateDefaultVolumeDisplayNodes(volumeNode)
+    volumeNode.CreateDefaultDisplayNodes()
   return volumeNode.GetDisplayNode()
 
 nib = _importOptional('nibabel')

--- a/DCE_TumorMapProcess/DCE_TumorMapProcess.py
+++ b/DCE_TumorMapProcess/DCE_TumorMapProcess.py
@@ -47,8 +47,11 @@ def _pipEnsure(package):
   try:
     import slicer.packaging
     slicer.packaging.pip_ensure(package, requester="Breast_DCEMRI_FTV")
-  except AttributeError:
-    slicer.util.pip_install(package)
+  except (AttributeError, ImportError, ModuleNotFoundError):
+    try:
+      slicer.util.pip_install(package)
+    except Exception:
+      slicer.util.pip_install(f"--user {package}")
 
 def _importOptional(package, moduleName=None):
   moduleName = moduleName or package

--- a/DCE_TumorMapProcess/DCE_TumorMapProcess.py
+++ b/DCE_TumorMapProcess/DCE_TumorMapProcess.py
@@ -63,6 +63,13 @@ def _importOptional(package, moduleName=None):
     _pipEnsure(package)
     return __import__(moduleName)
 
+def _ensureVolumeDisplayNode(volumeNode):
+  if volumeNode is None:
+    return None
+  if volumeNode.GetDisplayNode() is None:
+    slicer.modules.volumes.logic().CreateDefaultVolumeDisplayNodes(volumeNode)
+  return volumeNode.GetDisplayNode()
+
 nib = _importOptional('nibabel')
 cv2 = _importOptional('cv2', 'cv2')
 nrrd = _importOptional('pynrrd', 'nrrd')
@@ -612,14 +619,21 @@ class DCE_TumorMapProcessWidget(ScriptedLoadableModuleWidget):
     #Create ROI and add it to scene
     #Edit 6/8/2020: Make ROI always at center of image, regardless of image size
     inputVolume = self.inputSelector.currentNode()
+    if inputVolume is None:
+      slicer.util.errorDisplay("No volume loaded. Run Module 1 first.")
+      return
+    displayNode = _ensureVolumeDisplayNode(inputVolume)
+    if displayNode is None:
+      slicer.util.errorDisplay("Could not create display node for loaded volume.")
+      return
+    displayNode.SetAutoWindowLevel(False) #Do this to prevent auto window leveling
+    self.windowmin = displayNode.GetWindowLevelMin()
+    self.windowmax = displayNode.GetWindowLevelMax()
+
     img = inputVolume.GetImageData()
     rows,cols,slices = img.GetDimensions()
     roicenter = np.array([int(rows/2),int(cols/2),int(slices/2)])
     roiradius = np.array([100,100,40])
-
-    inputVolume.GetDisplayNode().SetAutoWindowLevel(False) #Do this to prevent auto window leveling
-    self.windowmin = inputVolume.GetDisplayNode().GetWindowLevelMin()
-    self.windowmax = inputVolume.GetDisplayNode().GetWindowLevelMax()
 
     #Read current node name
     self.currentnodename = self.inputSelector.currentNode().GetName()
@@ -1611,8 +1625,10 @@ class DCE_TumorMapProcessWidget(ScriptedLoadableModuleWidget):
       slicer.util.setSliceViewerLayers(foreground=self.segment_node,foregroundOpacity = self.fopac)
 
     inputVolume = self.inputSelector.currentNode()
-    inputVolume.GetDisplayNode().SetAutoWindowLevel(False) #Do this to prevent auto window leveling
-    inputVolume.GetDisplayNode().SetWindowLevel(self.window,self.level) #set window level to match prior image
+    displayNode = _ensureVolumeDisplayNode(inputVolume)
+    if displayNode is not None:
+      displayNode.SetAutoWindowLevel(False) #Do this to prevent auto window leveling
+      displayNode.SetWindowLevel(self.window,self.level) #set window level to match prior image
     img = inputVolume.GetImageData()
     rows,cols,slices = img.GetDimensions()
     #read inputVolume to numpy array

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "slicer-ext-breast-dcemri-ftv"
+version = "1.0.0"
+description = "Breast DCE-MRI Functional Tumor Volume extension for 3D Slicer"
+requires-python = ">=3.9"
+dependencies = [
+    "nibabel",
+    "opencv-python",
+    "pynrrd",
+    "yattag",
+    "scikit-image",
+]


### PR DESCRIPTION
## Summary

Updates Breast DCE-MRI FTV for 3D Slicer 5.10 and Python 3.12 while preserving the existing Module 1 / Module 2 workflow.

Changes include:
- Fix ROI node type for Slicer 5.4+ (`vtkMRMLMarkupsROINode` instead of deprecated line node)
- Replace deprecated `dicom` package with `pydicom` throughout
- Pip dependency fallback for read-only NFS installs and user-site packages
- Support nested DICOM exam layouts (e.g. `E670/1`, `E670/2`) for manual folder selection
- Create volume display nodes correctly in Slicer 5.10 so loaded exams appear in slice views
- Ensure DICOM database is open before loading (writable fallback under `~/.slicer/FTV_DICOM`)
- Disable semi-transparent fill on ROI/omit markups (outline only)
- Fix PDF report logo loading on Linux (case-sensitive `3DSlicerLogo.PNG` filename)
- Add `pyproject.toml` for extension packaging metadata

## Motivation

The extension worked on older Slicer versions but failed on Slicer 5.10 Linux (read-only NFS install): only one DCE folder listed for manual selection, volumes not displayed in viewers, Module 2 ROI errors, and PDF report generation failures.

## Test plan

Tested on Slicer 5.10.0 Linux with a nested exam layout (`20251201_v10/E670/1`, `E670/2`, …):

- [x] Module 1: manual DCE folder selection lists all nested series folders
- [x] Module 1: pre / early / late volumes load and display
- [x] Module 2: ROI setup, segmentation, and PDF report generation
- [x] Read-only NFS Slicer install with extension loaded via user site-packages

## Note for maintainers

No Extensions Index update should be needed — the existing entry already points at this repo’s `master` branch.

If helpful, please tag the current `master` before merge (e.g. `v1.0.0-slicer5.4`) so the pre–5.10 code remains available.

Contributors: Pouya Metanat (UCSF) — development and testing on Slicer 5.10 Linux.